### PR TITLE
Autoload extension on .log page

### DIFF
--- a/background.js
+++ b/background.js
@@ -622,3 +622,12 @@ chrome.action.onClicked.addListener((tab) => {
     });
   }
 });
+
+chrome.webNavigation.onCompleted.addListener(function(details) {
+  if (details.url.endsWith(".log")) {
+    chrome.scripting.executeScript({
+      target: { tabId: details.tabId },
+      function: colorizePre,
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
   "description": "Replace <pre> tags that contains ansi colors with colored <pre> tags",
   "permissions": [
     "activeTab",
-    "scripting"
+    "scripting",
+    "webNavigation"
   ],
   "host_permissions": ["*://*/"],
   "background": {


### PR DESCRIPTION
Automatically trigger the extension if viewing a page ending in `.log`